### PR TITLE
Added SSL support

### DIFF
--- a/src/New-GitHubRelease/New-GitHubRelease.psm1
+++ b/src/New-GitHubRelease/New-GitHubRelease.psm1
@@ -281,7 +281,7 @@ function Invoke-RestMethodAndThrowDescriptiveErrorOnFailure($requestParametersHa
 {
 	$requestDetailsAsNicelyFormattedString = Convert-HashTableToNicelyFormattedString $requestParametersHashTable
 	Write-Verbose "Making web request with the following parameters:$NewLine$requestDetailsAsNicelyFormattedString"
-
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 	try
 	{
 		$webRequestResult = Invoke-RestMethod @requestParametersHashTable


### PR DESCRIPTION
Release publishing fails if the security protocol isn't explicitly set.